### PR TITLE
Added docker-compose file for development.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  app:
+    image: jekyll/jekyll
+    command: jekyll serve --force_polling --incremental
+    volumes:
+      - $PWD:/srv/jekyll
+    ports:
+      - 4000:4000


### PR DESCRIPTION
ローカルで docker 使って開発ができるように docker-composeファイルを追加しました。

ソースコードを `git clone` し、ディレクトリに移動した後、

```bash
docker-compose -f docker-compose.dev.yml up
```

でサービス起動、port 4000番で動くので `[http://localhost:4000/](http://localhost:4000/)` でアクセスできます。