### PR TITLE
fix: activities一覧で不正な日付 2009-11-31 を 2009-11-30 に修正

### DIFF
--- a/_data/achievements.yml
+++ b/_data/achievements.yml
@@ -3181,10 +3181,10 @@ items:
     keyword: presentation
     lang: ja
 
-  - date: 2009-11-31
+  - date: 2009-11-30
     year: 2009
     month: 11
-    day: 31
+    day: 30
     id: 10-ja
     title: 共同利用としてのライフサイエンス基盤－日本DNAデータバンク（DDBJ）とライフサイエンス統合データベース（LSDB）
     author: 五條堀 孝


### PR DESCRIPTION
## 概要
`_data/achievements.yml` の発表記録 (id: 10-ja) の日付が存在しない日付 **2009-11-31**（11月は30日まで）になっていたため、**2009-11-30** に修正します。

## 不具合の内容
activities 一覧 (`/activities/`) のソートはクライアント側 JS (`_javascript/taggingListView.js`) が `<time datetime>` を `new Date()` でパースし flexbox の `order` で並べています。`2009-11-31` は厳格に日付検証するブラウザ (Firefox / Safari 等) では `Invalid Date` となり `getTime()` が `NaN`、結果 `element.style.order = NaN` が無効値として無視され `order: 0` のまま残ります。正常な項目は全て大きな正の `order` 値になるため、この1件だけが**一覧の先頭に表示される**不具合が出ていました。

## 修正
- `_data/achievements.yml`: `date: 2009-11-31` → `2009-11-30`、`day: 31` → `30`
- 同一シンポジウム「情報とシステム2009」の隣項目 (id: 9-ja) が `2009-11-30` のため、これに合わせました。

## 確認
- www-dev (development) で反映済み。一覧先頭が正しく最新日付の項目になり、当該項目は年代相当の位置 (254/300番目) に並ぶことを確認。
- データ1ファイルのみの変更で、JS 改修は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)